### PR TITLE
Add a new listener for port 19200 + Update existing to use port 9200

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -164,6 +164,10 @@ export class InfraStack extends Stack {
         port: 443,
         protocol: Protocol.TCP,
       });
+      opensearchListener19200 = nlb.addListener('elasticsearchHTTP', {
+        port: 80, // or some other port that makes sense in this context
+        protocol: Protocol.TCP,
+      });
     } else {
       opensearchListener = nlb.addListener('elasticsearch9200', {
         port: 9200,

--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -160,16 +160,16 @@ export class InfraStack extends Stack {
     });
 
     if (!props.securityDisabled && !props.minDistribution) {
-      opensearchListener = nlb.addListener('elasticsearch', {
+      opensearchListener = nlb.addListener('elasticsearchHTTPS', {
         port: 443,
         protocol: Protocol.TCP,
       });
     } else {
-      opensearchListener = nlb.addListener('elasticsearch', {
+      opensearchListener = nlb.addListener('elasticsearch9200', {
         port: 9200,
         protocol: Protocol.TCP,
       });
-      opensearchListener19200 = nlb.addListener('elasticsearch', {
+      opensearchListener19200 = nlb.addListener('elasticsearch19200', {
         port: 19200,
         protocol: Protocol.TCP,
       });

--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -105,6 +105,7 @@ export class InfraStack extends Stack {
   constructor(scope: Stack, id: string, props: infraProps) {
     super(scope, id, props);
     let opensearchListener: NetworkListener;
+    let opensearchListener19200: NetworkListener;
     let dashboardsListener: NetworkListener;
     let managerAsgCapacity: number;
     let dataAsgCapacity: number;
@@ -165,11 +166,11 @@ export class InfraStack extends Stack {
       });
     } else {
       opensearchListener = nlb.addListener('elasticsearch', {
-        port: 19200,
+        port: 9200,
         protocol: Protocol.TCP,
       });
-      opensearchListener = nlb.addListener('elasticsearch', {
-        port: 9200,
+      opensearchListener19200 = nlb.addListener('elasticsearch', {
+        port: 19200,
         protocol: Protocol.TCP,
       });
     }
@@ -217,7 +218,7 @@ export class InfraStack extends Stack {
         port: 9200,
         targets: [new InstanceTarget(singleNodeInstance)],
       });
-      opensearchListener.addTargets('single-node-target', {
+      opensearchListener19200.addTargets('single-node-target', {
         port: 19200,
         targets: [new InstanceTarget(singleNodeInstance)],
       });
@@ -401,7 +402,7 @@ export class InfraStack extends Stack {
         port: 9200,
         targets: [clientNodeAsg],
       });
-      opensearchListener.addTargets('elasticsearchTarget', {
+      opensearchListener19200.addTargets('elasticsearchTarget', {
         port: 19200,
         targets: [clientNodeAsg],
       });

--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -158,29 +158,21 @@ export class InfraStack extends Stack {
       crossZoneEnabled: true,
     });
 
-// Modify existing listener to use port 9200
-    opensearchListener = nlb.addListener('opensearch', {
-      port: 9200,
-      protocol: Protocol.TCP,
-    });
-
-// Add a new listener for port 19200
-    const opensearchListener19200 = nlb.addListener('opensearch19200', {
-      port: 19200,
-      protocol: Protocol.TCP,
-    });
-
-// Add targets for opensearchListener
-    opensearchListener.addTargets('opensearchTarget', {
-      port: 9200,
-      targets: [clientNodeAsg],
-    });
-
-// Add targets for opensearchListener19200
-    opensearchListener19200.addTargets('opensearchTarget19200', {
-      port: 19200,
-      targets: [clientNodeAsg],
-    });
+    if (!props.securityDisabled && !props.minDistribution) {
+      opensearchListener = nlb.addListener('elasticsearch', {
+        port: 443,
+        protocol: Protocol.TCP,
+      });
+    } else {
+      opensearchListener = nlb.addListener('elasticsearch', {
+        port: 19200,
+        protocol: Protocol.TCP,
+      });
+      opensearchListener = nlb.addListener('elasticsearch', {
+        port: 9200,
+        protocol: Protocol.TCP,
+      });
+    }
 
     if (props.dashboardsUrl !== 'undefined') {
       dashboardsListener = nlb.addListener('dashboards', {
@@ -223,6 +215,10 @@ export class InfraStack extends Stack {
 
       opensearchListener.addTargets('single-node-target', {
         port: 9200,
+        targets: [new InstanceTarget(singleNodeInstance)],
+      });
+      opensearchListener.addTargets('single-node-target', {
+        port: 19200,
         targets: [new InstanceTarget(singleNodeInstance)],
       });
 
@@ -403,6 +399,10 @@ export class InfraStack extends Stack {
 
       opensearchListener.addTargets('elasticsearchTarget', {
         port: 9200,
+        targets: [clientNodeAsg],
+      });
+      opensearchListener.addTargets('elasticsearchTarget', {
+        port: 19200,
         targets: [clientNodeAsg],
       });
 

--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -105,6 +105,7 @@ export class InfraStack extends Stack {
   constructor(scope: Stack, id: string, props: infraProps) {
     super(scope, id, props);
     let opensearchListener: NetworkListener;
+    let opensearchListener19200: NetworkListener;
     let dashboardsListener: NetworkListener;
     let managerAsgCapacity: number;
     let dataAsgCapacity: number;
@@ -165,7 +166,11 @@ export class InfraStack extends Stack {
       });
     } else {
       opensearchListener = nlb.addListener('elasticsearch', {
-        port: 80,
+        port: 9200,
+        protocol: Protocol.TCP,
+      });
+      opensearchListener19200 = nlb.addListener('elasticsearch', {
+        port: 19200,
         protocol: Protocol.TCP,
       });
     }
@@ -211,6 +216,10 @@ export class InfraStack extends Stack {
 
       opensearchListener.addTargets('single-node-target', {
         port: 9200,
+        targets: [new InstanceTarget(singleNodeInstance)],
+      });
+      opensearchListener19200.addTargets('single-node-target', {
+        port: 19200,
         targets: [new InstanceTarget(singleNodeInstance)],
       });
 
@@ -391,6 +400,10 @@ export class InfraStack extends Stack {
 
       opensearchListener.addTargets('elasticsearchTarget', {
         port: 9200,
+        targets: [clientNodeAsg],
+      });
+      opensearchListener19200.addTargets('elasticsearchTarget', {
+        port: 19200,
         targets: [clientNodeAsg],
       });
 

--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -159,25 +159,16 @@ export class InfraStack extends Stack {
       crossZoneEnabled: true,
     });
 
-    if (!props.securityDisabled && !props.minDistribution) {
-      opensearchListener = nlb.addListener('elasticsearchHTTPS', {
-        port: 443,
-        protocol: Protocol.TCP,
-      });
-      opensearchListener19200 = nlb.addListener('elasticsearchHTTP', {
-        port: 80, // or some other port that makes sense in this context
-        protocol: Protocol.TCP,
-      });
-    } else {
-      opensearchListener = nlb.addListener('elasticsearch9200', {
-        port: 9200,
-        protocol: Protocol.TCP,
-      });
-      opensearchListener19200 = nlb.addListener('elasticsearch19200', {
-        port: 19200,
-        protocol: Protocol.TCP,
-      });
-    }
+
+    opensearchListener = nlb.addListener('elasticsearch9200', {
+      port: 9200,
+      protocol: Protocol.TCP,
+    });
+    opensearchListener19200 = nlb.addListener('elasticsearch19200', {
+      port: 19200,
+      protocol: Protocol.TCP,
+    });
+
 
     if (props.dashboardsUrl !== 'undefined') {
       dashboardsListener = nlb.addListener('dashboards', {


### PR DESCRIPTION
This PR updates the load balancer created by adding a listener on port 19200 which forwards to port 19200 on source endpoint.
Also updates the existing listener so that it listens on port 9200 and forwards to port 9200.

This way, we can reach the capture proxy OR the source cluster if needed. This is necessary for the E2E tests to run since they must send requests directly to the source cluster without having to go through the capture proxy.