### PR TITLE
Made IMDSv2 optional on source node

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -217,7 +217,7 @@ export class InfraStack extends Stack {
         initOptions: {
           ignoreFailures: false,
         },
-        requireImdsv2: true,
+        requireImdsv2: false
       });
       Tags.of(singleNodeInstance).add('role', 'client');
 


### PR DESCRIPTION
Made EC2 IMDSv2 optional on the single-node source cluster we use for testing, which enables pre-Elasticsearch 7.X test clusters.  Before 7.X, the S3 Repository plugin only talks to IMDSv1, meaning nodes with IMDSv2-only were unable to send snapshots to S3.