### PR TITLE
Add option for not requiring Imdsv2 for older ES versions

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -73,7 +73,8 @@ export interface infraProps extends StackProps {
   readonly isInternal: boolean,
   readonly enableRemoteStore: boolean,
   readonly storageVolumeType: EbsDeviceVolumeType,
-  readonly customRoleArn: string
+  readonly customRoleArn: string,
+  readonly requireImdsv2: boolean,
 }
 
 export class InfraStack extends Stack {
@@ -217,7 +218,7 @@ export class InfraStack extends Stack {
         initOptions: {
           ignoreFailures: false,
         },
-        requireImdsv2: false
+        requireImdsv2: props.requireImdsv2,
       });
       Tags.of(singleNodeInstance).add('role', 'client');
 
@@ -273,7 +274,7 @@ export class InfraStack extends Stack {
           initOptions: {
             ignoreFailures: false,
           },
-          requireImdsv2: true,
+          requireImdsv2: props.requireImdsv2,
           signals: Signals.waitForAll(),
         });
         Tags.of(managerNodeAsg).add('role', 'manager');
@@ -307,7 +308,7 @@ export class InfraStack extends Stack {
         initOptions: {
           ignoreFailures: false,
         },
-        requireImdsv2: true,
+        requireImdsv2: props.requireImdsv2,
         signals: Signals.waitForAll(),
       });
       Tags.of(seedNodeAsg).add('role', 'manager');
@@ -335,7 +336,7 @@ export class InfraStack extends Stack {
         initOptions: {
           ignoreFailures: false,
         },
-        requireImdsv2: true,
+        requireImdsv2: props.requireImdsv2,
         signals: Signals.waitForAll(),
       });
       Tags.of(dataNodeAsg).add('role', 'data');
@@ -366,7 +367,7 @@ export class InfraStack extends Stack {
           initOptions: {
             ignoreFailures: false,
           },
-          requireImdsv2: true,
+          requireImdsv2: props.requireImdsv2,
           signals: Signals.waitForAll(),
         });
         Tags.of(clientNodeAsg).add('cluster', scope.stackName);
@@ -398,7 +399,7 @@ export class InfraStack extends Stack {
           initOptions: {
             ignoreFailures: false,
           },
-          requireImdsv2: true,
+          requireImdsv2: props.requireImdsv2,
           signals: Signals.waitForAll(),
         });
 

--- a/lib/os-cluster-entrypoint.ts
+++ b/lib/os-cluster-entrypoint.ts
@@ -217,6 +217,14 @@ export class OsClusterEntrypoint {
         mlNodeStorage = parseInt(mlSize, 10);
       }
 
+      // This setting only imposes a requirement that Imdsv2 be enabled for the single node EC2 instance or Auto
+      // Scaling Groups of the infra-stack. If disabled the EC2 instance will follow the order of precedence, as
+      // described here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html#instance-metadata-options-order-of-precedence,
+      // for whether it should enforce Imdsv2 or make it optional. The next place to check after the instance
+      // configuration is the account settings, which should allow both v1 and v2 if desired after disabling here.
+      const requireImdsv2Context = getContext(scope, jsonFileContext, 'requireImdsv2');
+      const requireImdsv2 = !(requireImdsv2Context === 'false');
+
       const jvmSysProps = getContext(scope, jsonFileContext, 'jvmSysProps');
 
       const osConfig = getContext(scope, jsonFileContext, 'additionalConfig');
@@ -319,6 +327,7 @@ export class OsClusterEntrypoint {
         enableRemoteStore,
         storageVolumeType: volumeType,
         customRoleArn,
+        requireImdsv2,
         ...props,
       });
 


### PR DESCRIPTION
This is to keep Imdsv2 as our default, while unblocking older ES versions which don't have support for Imdsv2