### PR TITLE
Fix ES_PATH_CONF not unset after temp dir cleanup in refresh script

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -670,6 +670,7 @@ echo -n "$ST" | "$ES_HOME/bin/elasticsearch-keystore" add -f -x s3.client.defaul
 cp "$TMP_CONF/elasticsearch.keystore" "$ES_HOME/config/elasticsearch.keystore"
 chmod 0600 "$ES_HOME/config/elasticsearch.keystore"
 rm -rf "$TMP_CONF"
+unset ES_PATH_CONF
 SCRIPTEOF
 chmod +x /home/ec2-user/refresh-es-keystore.sh
 chown ec2-user:ec2-user /home/ec2-user/refresh-es-keystore.sh`,


### PR DESCRIPTION
## Problem

After the IMDS credential refresh script (added in PR #8) copies the keystore back from the temp directory and removes it, `ES_PATH_CONF` remains exported pointing to the deleted temp dir. This causes subsequent `elasticsearch-keystore` commands to fail:

```
/home/ec2-user/elasticsearch/bin/elasticsearch-env: line 79: cd: /tmp/tmp.XXXXXXXX: No such file or directory
```

## Fix

Added `unset ES_PATH_CONF` after `rm -rf "$TMP_CONF"` in the refresh script so the environment variable doesn't point to a nonexistent directory.

## Diff

```diff
 cp "$TMP_CONF/elasticsearch.keystore" "$ES_HOME/config/elasticsearch.keystore"
 chmod 0600 "$ES_HOME/config/elasticsearch.keystore"
 rm -rf "$TMP_CONF"
+unset ES_PATH_CONF
```

## Context

This fix was originally intended for PR #8 but that PR was merged before this commit landed.